### PR TITLE
XML-IO for HKLIntensityCorr

### DIFF
--- a/MStruct/IO.cpp
+++ b/MStruct/IO.cpp
@@ -91,7 +91,7 @@ void PowderPatternDiffraction::XMLOutput(ostream &os,int indent)const
    
    //mCorrTexture.XMLOutput(os,indent);
    
-   //mCorrHKLIntensity.XMLOutput(os,indent);
+   mCorrHKLIntensity.XMLOutput(os,indent);
 	   
    #if 0
    if(mFhklObsSq.numElements()>0)
@@ -178,6 +178,7 @@ void PowderPatternDiffraction::XMLInput(istream &is,const XMLCrystTag &tagg)
 		XMLCrystTag tag(is);
 		if(("PowderPatternCrystal"==tag.GetName())&&tag.IsEndTag())
 		{
+			// Note: HKLIntensity corrections are generated later in PowderPattern if needed, as at that time sinTh/lambda is already known
 			this->UpdateDisplay();
 			VFN_DEBUG_EXIT("MStruct::PowderPatternDiffraction::XMLInput():"<<this->GetName(),11)
 			return;
@@ -262,6 +263,10 @@ void PowderPatternDiffraction::XMLInput(istream &is,const XMLCrystTag &tagg)
 		if("AbsorptionCorr"==tag.GetName())
 		{
 			mCorrAbsorption.XMLInput(is,tag);
+		}
+		if("ArbitraryTexture"==tag.GetName())
+		{
+			mCorrHKLIntensity.XMLInput(is,tag);
 		}
 		if("ReflectionProfilePseudoVoigt"==tag.GetName())
 		{
@@ -579,6 +584,20 @@ void PowderPattern::XMLInput(istream &is,const XMLCrystTag &tagg)
       XMLCrystTag tag(is);
       if(("PowderPattern"==tag.GetName())&&tag.IsEndTag())
       {
+         // Generate HKLIntensity corrections
+         for(int icomp=0; icomp<GetNbPowderPatternComponent(); icomp++) {
+           if(GetPowderPatternComponent(icomp).GetClassName().compare("MStruct::PowderPatternDiffraction") != 0)
+              continue;
+           MStruct::PowderPatternDiffraction & comp = dynamic_cast<MStruct::PowderPatternDiffraction&>(GetPowderPatternComponent(icomp));
+           int choice = comp.GetHKLIntensityCorrChoice();
+           // reset all parameters if choice is different from HKL_INTENSITY_CORRECTION_READ
+           if(choice != HKLIntensityCorr::HKL_INTENSITY_CORRECTION_READ)
+              comp.ResetHKLIntensityCorr();
+           if((choice == HKLIntensityCorr::HKL_INTENSITY_CORRECTION_GENERATE) || (choice == HKLIntensityCorr::HKL_INTENSITY_CORRECTION_FREE_ALL)) {
+              REAL level = (choice==HKLIntensityCorr::HKL_INTENSITY_CORRECTION_FREE_ALL) ? 0.04 : -1.;
+              comp.GenerateHKLIntensityCorrForAllReflections(level);
+           }
+         }
          this->UpdateDisplay();
          VFN_DEBUG_EXIT("MStruct::PowderPattern::XMLInput():"<<this->GetName(),5)
          return;
@@ -667,7 +686,7 @@ void PowderPattern::XMLInput(istream &is,const XMLCrystTag &tagg)
       {
          MStruct::PowderPatternDiffraction *comp=new MStruct::PowderPatternDiffraction;
          comp->SetParentPowderPattern(*this);
-				 comp->SetIncidenceAngle(mOmega);
+         comp->SetIncidenceAngle(mOmega);
          comp->XMLInput(is,tag);
          continue;
       }
@@ -851,6 +870,177 @@ void AbsorptionCorr::XMLInput(istream &is,const XMLCrystTag &tagg)
 		if("AbsorptionFactor"==tagg.GetAttributeName(i)) mAbsFactor = atof(tagg.GetAttributeValue(i).c_str())*1e-8;
 	}
 	VFN_DEBUG_EXIT("AbsorptionCorr::XMLInput():"<<this->GetName(),11)
+}
+
+////////////////////////////////////////////////////////////////////////
+//
+//    I/O HKLIntensityCorr
+//
+////////////////////////////////////////////////////////////////////////
+
+void HKLIntensityCorr::XMLOutput(ostream &os,int indent)const
+{
+	VFN_DEBUG_ENTRY("MStruct::HKLIntensityCorr::XMLOutput():"<<this->GetName(),11)
+	for(int i=0; i<indent; i++) os << "  ";
+	XMLCrystTag tag("ArbitraryTexture");
+	tag.AddAttribute("Name", this->GetName());
+	tag.AddAttribute("Tag", "Current");
+	tag.SetIsEmptyTag(false);
+	os << tag << endl;
+    indent++;
+
+    // --- options ---
+    mConfigChoice.XMLOutput(os,indent);
+    os << endl;
+
+    // --- reflections ---
+    if(mpData != NULL)
+        mpData->GetFhklCalcSq();
+
+    for(int irefl=0; irefl<mReflStore.size(); irefl++) {
+        for(int i=0; i<indent; i++) os << "  ";
+        XMLCrystTag tag("Par");
+        tag.SetIsEmptyTag(false);
+        const HKLIntensityCorr::IntensityCorrData *data =
+            (const HKLIntensityCorr::IntensityCorrData*)mReflStore.at(irefl).data;
+        const ObjCryst::RefinablePar & par = this->GetPar(&(data->val));
+        // Refined
+        tag.AddAttribute("Refined", (boost::format("%d") % !par.IsFixed()).str());
+        // Limited
+        tag.AddAttribute("Limited", (boost::format("%d") % par.IsLimited()).str());
+        // Min
+        tag.AddAttribute("Min", (boost::format("%g") % par.GetHumanMin()).str());
+        // Max
+        tag.AddAttribute("Max", (boost::format("%g") % par.GetHumanMax()).str());
+        // Name
+        tag.AddAttribute("Name", par.GetName());
+        // Position: 2Theta(deg)
+        REAL pos = (((data->i)>=0) && ((data->i)<mpData->GetNbRefl())) ? (2*mpData->GetTheta()(data->i)*RAD2DEG) : (-1);
+        tag.AddAttribute("2Theta", (boost::format("%.3f") % pos).str());
+        // SFactSqMult: |Fhkl|^2 * mult
+        REAL sFactSqMult = (((data->i)>=0) && ((data->i)<mpData->GetNbRefl())) ? (mpData->GetFhklCalcSq()(data->i)*mpData->GetMultiplicity()(data->i)) : (-1);
+        tag.AddAttribute("SFactSqMult", (boost::format("%.2e") % sFactSqMult).str());
+        // H
+        tag.AddAttribute("H", (boost::format("%d") % mReflStore.at(irefl).H).str());
+        // K
+        tag.AddAttribute("K", (boost::format("%d") % mReflStore.at(irefl).K).str());
+        // L
+        tag.AddAttribute("L", (boost::format("%d") % mReflStore.at(irefl).L).str());
+        // Value
+        os << tag <<  (boost::format("%g") % data->val).str();
+        // EndTag
+        tag.SetIsEndTag(true);
+        os << tag << endl;
+    } // irefl
+
+    indent--;
+    tag.SetIsEndTag(true);
+    for(int i=0; i<indent; i++) os << "  ";
+    os << tag << endl;
+
+	VFN_DEBUG_EXIT("MStruct::HKLIntensityCorr::XMLOutput():"<<this->GetName(),11)
+}
+
+void HKLIntensityCorr::XMLInput(istream &is,const XMLCrystTag &tagg)
+{
+	VFN_DEBUG_ENTRY("MStruct::HKLIntensityCorr::XMLInput():"<<this->GetName(),11)
+    string _name("HKLIntensityCorr");
+    string _tag("");
+	for(unsigned int i=0;i<tagg.GetNbAttribute();i++)
+	{
+		if("Name"==tagg.GetAttributeName(i)) _name = tagg.GetAttributeValue(i);
+		if("Tag"==tagg.GetAttributeName(i)) _tag = tagg.GetAttributeValue(i);
+	}
+    int _h, _k, _l;
+    REAL _min, _max;
+    bool _fixed, _limited;
+    int _choice = HKL_INTENSITY_CORRECTION_READ;
+    if(_tag=="Current") {
+        this->SetName(_name);
+    	while(true)
+    	{
+    		XMLCrystTag tag(is);
+    		if(("ArbitraryTexture"==tag.GetName())&&tag.IsEndTag())
+    		{
+    			// Note: HKLIntensity corrections are generated later in PowderPattern if needed, as at that time sinTh/lambda is already known
+    			this->UpdateDisplay();
+    			VFN_DEBUG_EXIT("MStruct::HKLIntensityCorr::XMLInput()"<<this->GetName(),11)
+    			return;
+    		}
+    		if("Option"==tag.GetName())
+    		{
+    			for(unsigned int i=0;i<tag.GetNbAttribute();i++)
+    				if("Name"==tag.GetAttributeName(i))
+    					mOptionRegistry.GetObj(tag.GetAttributeValue(i)).XMLInput(is,tag);
+    			_choice = mConfigChoice.GetChoice();
+    			continue;
+    		}
+    		if("Par"==tag.GetName())
+    		{
+    			for(unsigned int i=0;i<tag.GetNbAttribute();i++)
+    			{
+    				if("H"==tag.GetAttributeName(i))
+    				{
+    					_h = atoi( tag.GetAttributeValue(i).c_str() );
+    					continue;
+    				}
+    				if("K"==tag.GetAttributeName(i))
+    				{
+    					_k = atoi( tag.GetAttributeValue(i).c_str() );
+    					continue;
+    				}
+    				if("L"==tag.GetAttributeName(i))
+    				{
+    					_l = atoi( tag.GetAttributeValue(i).c_str() );
+    					continue;
+    				}
+    				if("Refined"==tag.GetAttributeName(i))
+    				{
+    					_fixed = atoi( tag.GetAttributeValue(i).c_str() ) != 1;
+    					continue;
+    				}
+    				if("Limited"==tag.GetAttributeName(i))
+    				{
+    					_limited = atoi( tag.GetAttributeValue(i).c_str() ) == 1;
+    					continue;
+    				}
+    				if("Max"==tag.GetAttributeName(i))
+    				{
+                        istringstream istr( tag.GetAttributeValue(i) + " " );
+    					_max = InputFloat(istr,' ');
+    					continue;
+    				}
+    				if("Min"==tag.GetAttributeName(i))
+    				{
+                        istringstream istr( tag.GetAttributeValue(i) + " " );
+    					_min = InputFloat(istr,' ');
+    					continue;
+    				}
+    			}
+                REAL f = InputFloat(is,'<');
+                if(ISNAN_OR_INF(f)) f = 1.0;
+                if(_choice == HKL_INTENSITY_CORRECTION_READ) {
+                    this->SetHKLIntensityCorr(_h,_k,_l,f,_fixed);
+                    // limited, min, max
+                    int ind = mReflStore.find(_h,_k,_l,0.); // try to find (hkl) reflection in the "store"
+                    if(ind>=0) {
+                      const IntensityCorrData * pData = (const IntensityCorrData*) mReflStore.at(ind).data;
+                      RefinablePar &par = this->GetPar(&(pData->val));
+                      par.SetIsLimited(_limited);
+                      par.SetMin(_min);
+                      par.SetMax(_max);
+                    } else {
+                        cerr << "[Warning:ArbitraryTexture] Could not set limits for reflection: " << mpData->GetName();
+                        cerr << " (" << _h << "," << _k << "," << _l << ")\n";
+                    }
+                }
+                //read end tag
+                XMLCrystTag junk(is);
+    			continue;
+    		}
+    	}
+    }
+	VFN_DEBUG_EXIT("MStruct::HKLIntensityCorr::XMLInput():"<<this->GetName(),11)
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -1457,7 +1647,6 @@ void ReflectionProfile::XMLInput(istream &is,const XMLCrystTag &tagg)
 			MStruct::ResidualStressPositionCorrection * t = new MStruct::ResidualStressPositionCorrection();
 			t->SetParentReflectionProfile(*this);
 			this->AddReflectionProfileComponent(*t);
-			cout << "ParentReflectionProfile_test: " << this->GetParentPowderPatternDiffraction().GetName() << endl;
 			t->XMLInput(is,tag);
 			continue;
 		}

--- a/MStruct/MStruct.h
+++ b/MStruct/MStruct.h
@@ -14,7 +14,7 @@
  * MStruct++ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ * (at your option) any later version.;
  *
  * MStruct++ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -910,7 +910,7 @@ private:
 
 // TextureCorr
 class TextureCorr:public ScatteringCorr,
-                  public ObjCryst::RefinableObj {
+                  virtual public ObjCryst::RefinableObj {
 public:
   class TexturePhase {
   public:
@@ -956,7 +956,7 @@ private:
 
 // HKLIntensityCorr
 class HKLIntensityCorr:public ScatteringCorr,
-                       public ObjCryst::RefinableObj {
+                       virtual public ObjCryst::RefinableObj {
 public:
   class IntensityCorrData {
   public:
@@ -973,11 +973,23 @@ public:
   virtual void BeginOptimization(const bool allowApproximations=false,
 				 const bool enableRestraints=false);
   const ReflStore& GetReflStore()const;
+  void XMLOutput(ostream &os, int indent=0) const;
+  void XMLInput(istream &is, const ObjCryst::XMLCrystTag &tag);
+  static const int HKL_INTENSITY_CORRECTION_NONE     = 0;
+  static const int HKL_INTENSITY_CORRECTION_GENERATE = 1;
+  static const int HKL_INTENSITY_CORRECTION_FREE_ALL = 2;
+  static const int HKL_INTENSITY_CORRECTION_READ     = 3;
+  void SetChoice(const int choice);
+  int GetChoice() const;
+  void GenerateHKLIntensityCorrForAllReflections(const REAL relIntensity=-1.);
 protected:
   virtual void CalcCorr() const;
 protected:
   mutable ObjCryst::RefinableObjClock mClockIndexesCalc;
   ReflStore mReflStore;
+  ObjCryst::RefObjOpt mConfigChoice;
+private:
+  void InitOptions();
 }; // HKLIntensityCorr()
 
 // PowderPatternDiffraction
@@ -999,6 +1011,9 @@ public:
   void SetAbsorptionCorrParams(REAL thickness, REAL depth, REAL absfactor,REAL omega);
   void SetTextureCorrParams(REAL omega);
   void AddTextureCorrPhase(REAL fraction,const CrystVector_REAL& params, bool bForceTextureSymmetry=false);
+  void SetHKLIntensityCorrChoice(int choice);
+  void ResetHKLIntensityCorr();
+  int GetHKLIntensityCorrChoice() const;
   void SetHKLIntensityCorrParams(int h, int k, int l, REAL val, bool fixed=false);
   void GenerateHKLIntensityCorrForAllReflections(const REAL relIntensity=-1.);
   void PrintHKLIntensityCorr(ostream& s)const;

--- a/MStruct/mstruct_am.cpp
+++ b/MStruct/mstruct_am.cpp
@@ -740,6 +740,7 @@ int main (int argc, char *argv[])
      vHKLChoicePrint.push_back(0);
      read_line (ccin, imp_file); // read a line (ignoring all comments, etc.)
      ccin >> vHKLChoice[iphase];
+     vDiffData[iphase]->SetHKLIntensityCorrChoice(vHKLChoice[iphase]);
      if (vHKLChoice[iphase]>0) ccin >> vHKLChoicePrint[iphase];
      if(vHKLChoice[iphase]>0 && vHKLChoice[iphase]<3) {
        REAL level= (vHKLChoice[iphase]==2) ? 0.04 : -1.;

--- a/ObjCryst/ObjCryst/ScatteringData.cpp
+++ b/ObjCryst/ObjCryst/ScatteringData.cpp
@@ -722,6 +722,13 @@ const CrystVector_REAL& ScatteringData::GetFhklCalcSq() const
    return mFhklCalcSq;
 }
 
+const CrystVector_int& ScatteringData::GetMultiplicity() const
+{
+   VFN_DEBUG_ENTRY("ScatteringData::GetMultiplicity()",2)
+   VFN_DEBUG_EXIT("ScatteringData::GetMultiplicity()",2)
+   return mMultiplicity;
+}
+
 std::map<RefinablePar*, CrystVector_REAL>& ScatteringData::GetFhklCalcSq_FullDeriv(std::set<RefinablePar *> &vPar)
 {
    TAU_PROFILE("ScatteringData::GetFhklCalcSq_FullDeriv()","void ()",TAU_DEFAULT);

--- a/ObjCryst/ObjCryst/ScatteringData.h
+++ b/ObjCryst/ObjCryst/ScatteringData.h
@@ -407,6 +407,8 @@ class ScatteringData: virtual public RefinableObj
 
       ///  Returns the Array of calculated |F(hkl)|^2 for all reflections.
       const CrystVector_REAL& GetFhklCalcSq() const;
+      ///  Returns the Array of multiplicities for all reflections.
+      const CrystVector_int& GetMultiplicity() const;
       std::map<RefinablePar*, CrystVector_REAL> & GetFhklCalcSq_FullDeriv(std::set<RefinablePar *> &vPar);
       /// Access to real part of F(hkl)calc
       const CrystVector_REAL& GetFhklCalcReal() const;


### PR DESCRIPTION
XML Output/Input interface for `HKLIntensityCorr` aka `ArbitraryTexture`.

Example xml-code:
```html
<ArbitraryTexture Name="HKLIntensityCorr_Anatase" Tag="Current">
  <Option Name="ArbitraryTexture.choice" Choice="3" ChoiceName="Read"/>
  <Par Refined="1" Limited="1" Min="0" Max="200000" Name="diffData_Anatase_Ihkl_1_0_1" 2Theta="25.320" SFactSqMult="2.55e+04" H="1" K="0" L="1">1.09739</Par>
  <Par Refined="0" Limited="1" Min="0" Max="100000" Name="diffData_Anatase_Ihkl_1_0_3" 2Theta="36.984" SFactSqMult="3.04e+03" H="1" K="0" L="3">1</Par>
  <Par Refined="0" Limited="1" Min="0" Max="100000" Name="diffData_Anatase_Ihkl_0_0_4" 2Theta="37.839" SFactSqMult="1.26e+04" H="0" K="0" L="4">1</Par>
</ArbitraryTexture>
```

Choices options:
```html
<Option Name="ArbitraryTexture.choice" Choice="0" ChoiceName="None"/>
<Option Name="ArbitraryTexture.choice" Choice="1" ChoiceName="Generate"/>
<Option Name="ArbitraryTexture.choice" Choice="2" ChoiceName="Free all"/>
<Option Name="ArbitraryTexture.choice" Choice="3" ChoiceName="Read"/>
```